### PR TITLE
Added 'time' for millisecond-resolution timestamps in stackdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ var gke = require('winston-gke');
 
 var logger = gke(new winston.Logger());
 
-logger.debug('debug!'); // {"severity":"DEBUG","message":"debug!"}
-logger.info('info!', {somekey: 'This is some metadata'}); // {"severity":"INFO","message":"info!","meta":{"somekey":"This is some metadata"}}
+logger.debug('debug!'); // {"time":"2017-12-13T18:07:20.226Z","severity":"DEBUG","message":"debug!"}
+logger.info('info!', {somekey: 'This is some metadata'}); // {"time":"2017-12-13T18:07:20.437Z","severity":"INFO","message":"info!","meta":{"somekey":"This is some metadata"}}
 ```

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function(logger, level) {
         Object.assign(
           options.meta && Object.keys(options.meta).length ? {meta: options.meta} : {},
           {
+            time: new Date().toISOString(),
             severity: options.level.toUpperCase(),
             message: options.message
           }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "expect": "^1.20.1",
     "mocha": "^2.4.5",
+    "sinon": "^4.1.3",
     "std-mocks": "^1.0.1",
     "winston": "^2.2.0"
   },

--- a/test.js
+++ b/test.js
@@ -3,10 +3,17 @@
 var gke = require('./');
 var winston = require('winston');
 
+var sinon = require('sinon');
 var stdMocks = require('std-mocks');
 var expect = require('expect');
 
 describe('winston-gke', function() {
+  beforeEach(function() {
+    this.clock = sinon.useFakeTimers();
+  });
+  afterEach(function() {
+    this.clock.restore();
+  });
 
   it('sets log levels that match google stackdriver\'s level', function() {
     var logger = gke(new winston.Logger());
@@ -60,7 +67,7 @@ describe('winston-gke', function() {
     stdMocks.restore();
     output = stdMocks.flush();
 
-    expect(output.stdout).toEqual('{"severity":"WARNING","message":"message"}\n');
+    expect(output.stdout).toEqual('{"time":"1970-01-01T00:00:00.000Z","severity":"WARNING","message":"message"}\n');
 
     stdMocks.use();
 
@@ -68,7 +75,7 @@ describe('winston-gke', function() {
     stdMocks.restore();
     output = stdMocks.flush();
 
-    expect(output.stdout).toEqual('{"meta":{"anything":"This is metadata"},"severity":"INFO","message":"info message"}\n');
+    expect(output.stdout).toEqual('{"meta":{"anything":"This is metadata"},"time":"1970-01-01T00:00:00.000Z","severity":"INFO","message":"info message"}\n');
 
   });
 


### PR DESCRIPTION
I added a `time` property, which is then used by fluent-plugin-google-cloud as the timestamp for the log message.  This allows for millisecond-level resolution, which can be helpful when logs are verbose. 

Before:
`2017-12-12 16:16:52.000 PST
::ffff:10.4.1.1 - - [13/Dec/2017:00:16:52 +0000] "GET /status HTTP/1.1" 200 15 "-" "kube-probe/1.8+" 85.966 ms`

After:
`2017-12-13 08:35:14.913 PST
::ffff:10.4.1.1 - - [13/Dec/2017:16:35:14 +0000] "GET /status HTTP/1.1" 200 15 "-" "kube-probe/1.8+" 72.312 ms`

https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/f5b7d17ea235611bbe3338997883d4b78562af59/lib/fluent/plugin/out_google_cloud.rb#L488